### PR TITLE
Display nodraw brushes that are solid (invisible walls in some maps)

### DIFF
--- a/addons/sourcemod/gamedata/showplayerclips.games.txt
+++ b/addons/sourcemod/gamedata/showplayerclips.games.txt
@@ -92,6 +92,7 @@
 			"CCollisionBSPData::map_cmodels"	"184"
 			"CCollisionBSPData::numbrushes"		"192"
 			"CCollisionBSPData::map_brushes"	"196"
+			"CCollisionBSPData::map_surfaces"	"588"
 			//...
 		}
 		

--- a/addons/sourcemod/scripting/showplayerclips.sp
+++ b/addons/sourcemod/scripting/showplayerclips.sp
@@ -11,7 +11,7 @@
 #define TRANSLATE_FILENAME "showplayerclips.phrases"
 
 #define MAX_TEMPENTS_SEND (255 - 24)
-#define PVIS_COUNT 3
+#define PVIS_COUNT 4
 #define TEMPENT_MIN_LIFETIME 1.0
 #define TEMPENT_MAX_LIFETIME 25.0
 #define INTERNAL_REFRESHTIME 0.1
@@ -24,8 +24,8 @@ public Plugin myinfo =
 {
 	name = "Show Player Clip Brushes",
 	author = "GAMMA CASE",
-	description = "Shows player clip brushes on map.",
-	version = "1.1.3",
+	description = "Shows player clip and nodraw brushes on map.",
+	version = "1.1.4",
 	url = "https://github.com/GAMMACASE/ShowPlayerClips"
 };
 
@@ -260,7 +260,7 @@ public void OnMapEnd()
 			gpVis[i] = view_as<Leafvis_t>(0);
 		
 		delete gFinalVerts[i];
-		for(int j = 0; j < sizeof(gColor); j++)
+		for(int j = 0; j < sizeof(gColor[]); j++)
 			gColor[i][j] = 0;
 	}
 	
@@ -600,7 +600,7 @@ stock void BytePatchTELimit(Handle gconf)
 
 void RecomputeClipbrushes()
 {
-	int ibrush, contents[PVIS_COUNT] = {CONTENTS_PLAYERCLIP|CONTENTS_MONSTERCLIP, CONTENTS_MONSTERCLIP, CONTENTS_PLAYERCLIP};
+	int ibrush, contents[PVIS_COUNT] = {CONTENTS_PLAYERCLIP|CONTENTS_MONSTERCLIP, CONTENTS_MONSTERCLIP, CONTENTS_PLAYERCLIP, SURF_NODRAW};
 	
 	ArrayList planeList = new ArrayList(4);
 	float normal[3], mins[3], maxs[3];
@@ -621,34 +621,93 @@ void RecomputeClipbrushes()
 		vertCountList.Clear();
 		
 		gColor[j][0] = (j != 1 ? 255 : 125);
-		gColor[j][1] = 0;
-		gColor[j][2] = (j != 0 ? 255 : 0);
+		gColor[j][1] = (j < 3 ? 0 : 255);
+		gColor[j][2] = (0 < j < 3 ? 255 : 0);
 		gColor[j][3] = gCvarBeamAlpha.IntValue;
 		
 		for(ibrush = 0; ibrush < lastBrush; ibrush++)
 		{
 			pBrush = view_as<Cbrush_t>(gpBSPData.map_brushes.Get(ibrush, Cbrush_t.Size()));
-			if((pBrush.contents & (CONTENTS_PLAYERCLIP | CONTENTS_MONSTERCLIP)) == contents[j])
+			
+			if(j < 3)
 			{
-				planeList.Clear();
+				if((pBrush.contents & (CONTENTS_PLAYERCLIP | CONTENTS_MONSTERCLIP)) == contents[j])
+				{
+					planeList.Clear();
+					
+					if(pBrush.IsBox())
+					{
+						pBox = view_as<Cboxbrush_t>(gpBSPData.map_boxbrushes.Get(pBrush.GetBox(), Cboxbrush_t.Size()));
+						pBox.mins.ToArray(mins);
+						pBox.maxs.ToArray(maxs);
+						
+						for(int i = 0; i < 3; i++)
+						{
+							normal[0] = 0.0;
+							normal[1] = 0.0;
+							normal[2] = 0.0;
+							
+							normal[i] = 1.0;
+							
+							AddPlaneToList(planeList, normal, maxs[i], true);
+							NegateVector(normal);
+							AddPlaneToList(planeList, normal, -mins[i], true);
+						}
+					}
+					else
+					{
+						for(int i = 0; i < pBrush.numsides; i++)
+						{
+							pSide = view_as<Cbrushside_t>(gpBSPData.map_brushsides.Get(pBrush.firstbrushside + i, Cbrushside_t.Size()));
+							
+							if(pSide.bBevel == 1)
+								continue;
+							
+							pSide.plane.normal.ToArray(normal);
+							
+							AddPlaneToList(planeList, normal, pSide.plane.dist, true);
+						}
+					}
+					
+					CSGPlaneList(planeList, vertsList, vertCountList);
+				}
+			}
+			else
+			{
+				if((pBrush.contents & (CONTENTS_PLAYERCLIP)) || (pBrush.contents & (CONTENTS_MONSTERCLIP)))
+					continue;
+				if(!(pBrush.contents & (MASK_PLAYERSOLID)))
+					continue;
+				if(pBrush.contents & (MASK_VISIBLE)) //unfortunately this doesn't show the brushes like on bhop_gnite.. as they are CONTENTS_OPAQUE.. and if you display those, it displays all sorts of other brush geometry in maps ):
+					continue;
 				
 				if(pBrush.IsBox())
 				{
 					pBox = view_as<Cboxbrush_t>(gpBSPData.map_boxbrushes.Get(pBrush.GetBox(), Cboxbrush_t.Size()));
-					pBox.mins.ToArray(mins);
-					pBox.maxs.ToArray(maxs);
-					
-					for(int i = 0; i < 3; i++)
+					int iSurfaceIndex[6];
+					pBox.surfaceIndex(iSurfaceIndex);
+					for(int k = 0; k < 6; k++)
 					{
-						normal[0] = 0.0;
-						normal[1] = 0.0;
-						normal[2] = 0.0;
-						
-						normal[i] = 1.0;
-						
-						AddPlaneToList(planeList, normal, maxs[i], true);
-						NegateVector(normal);
-						AddPlaneToList(planeList, normal, -mins[i], true);
+						int flags = gpBSPData.getSurfaceFlags(iSurfaceIndex[k]);
+						if((flags & (SURF_NODRAW)) == 0)
+						{
+							planeList.Clear();
+							pBox.mins.ToArray(mins);
+							pBox.maxs.ToArray(maxs);
+							
+							for(int i = 0; i < 3; i++)
+							{
+								normal[0] = 0.0;
+								normal[1] = 0.0;
+								normal[2] = 0.0;
+								
+								normal[i] = 1.0;
+								
+								AddPlaneToList(planeList, normal, maxs[i], true);
+								NegateVector(normal);
+								AddPlaneToList(planeList, normal, -mins[i], true);
+							}
+						}
 					}
 				}
 				else
@@ -656,13 +715,18 @@ void RecomputeClipbrushes()
 					for(int i = 0; i < pBrush.numsides; i++)
 					{
 						pSide = view_as<Cbrushside_t>(gpBSPData.map_brushsides.Get(pBrush.firstbrushside + i, Cbrushside_t.Size()));
-						
-						if(pSide.bBevel == 1)
-							continue;
-						
-						pSide.plane.normal.ToArray(normal);
-						
-						AddPlaneToList(planeList, normal, pSide.plane.dist, true);
+						int flags = gpBSPData.getSurfaceFlags(pSide.surfaceIndex);
+						if((flags & (SURF_NODRAW)) == 0)
+						{
+							if(pSide.bBevel == 1)
+								continue;
+							
+							planeList.Clear();
+							
+							pSide.plane.normal.ToArray(normal);
+							
+							AddPlaneToList(planeList, normal, pSide.plane.dist, true);
+						}
 					}
 				}
 				

--- a/addons/sourcemod/scripting/spc/methodmaps.sp
+++ b/addons/sourcemod/scripting/spc/methodmaps.sp
@@ -840,7 +840,9 @@ enum CCollisionBSPData_members
 	CCollisionBSPData_numbrushes,
 	CCollisionBSPData_map_brushes,
 	CCollisionBSPData_numdisplist,
-	CCollisionBSPData_map_dispList
+	CCollisionBSPData_map_dispList,
+	CCollisionBSPData_map_surfaces
+	
 	//...
 };
 static int CCollisionBSPData_offsets[CCollisionBSPData_members];
@@ -923,6 +925,22 @@ methodmap CCollisionBSPData < AddressBase
 		public get() { return view_as<CRangeValidatedArray>(this.Address + CCollisionBSPData_offsets[CCollisionBSPData_map_brushes]); }
 	}
 	
+	property CRangeValidatedArray map_surfaces
+	{
+		public get() { return view_as<CRangeValidatedArray>(this.Address + CCollisionBSPData_offsets[CCollisionBSPData_map_surfaces]); }
+	}
+	
+	public int getSurfaceAtIndex(int index)
+	{ 
+		Address map_surfaces = LoadFromAddress(view_as<Address>(this.Address + 588), NumberType_Int32);
+		return LoadFromAddress(view_as<Address>(map_surfaces + (8*index)), NumberType_Int32);
+	}
+	
+	public int getSurfaceFlags(int index)
+	{
+		Address surface = view_as<Address>(this.getSurfaceAtIndex(index));
+		return LoadFromAddress(view_as<Address>(surface + 6), NumberType_Int16);
+	}
 	//...
 }
 
@@ -1025,6 +1043,8 @@ void RetrieveOffsets(Handle gconf)
 			CCollisionBSPData_offsets[CCollisionBSPData_numbrushes] = StringToInt(buff);
 			GameConfGetKeyValue(gconf, "CCollisionBSPData::map_brushes", buff, sizeof(buff));
 			CCollisionBSPData_offsets[CCollisionBSPData_map_brushes] = StringToInt(buff);
+			GameConfGetKeyValue(gconf, "CCollisionBSPData::map_surfaces", buff, sizeof(buff));
+			CCollisionBSPData_offsets[CCollisionBSPData_map_surfaces] = StringToInt(buff);
 		}
 	}
 	else if(gOSType == OSLinux)
@@ -1132,6 +1152,8 @@ void RetrieveOffsets(Handle gconf)
 		CCollisionBSPData_offsets[CCollisionBSPData_numbrushes] = StringToInt(buff);
 		GameConfGetKeyValue(gconf, "CCollisionBSPData::map_brushes", buff, sizeof(buff));
 		CCollisionBSPData_offsets[CCollisionBSPData_map_brushes] = StringToInt(buff);
+		GameConfGetKeyValue(gconf, "CCollisionBSPData::map_surfaces", buff, sizeof(buff));
+		CCollisionBSPData_offsets[CCollisionBSPData_map_surfaces] = StringToInt(buff);
 		
 		//cplane_t
 		GameConfGetKeyValue(gconf, "cplane_t::normal", buff, sizeof(buff));


### PR DESCRIPTION
Some maps (like bhop_paskaaa) have invisible walls that don't display due to them not being playerclips, but instead one of the numerous %nodraw materials available. This PR handles these and displays them as yellow beams.
![20260326110549_1](https://github.com/user-attachments/assets/0d9f2fff-eb36-4cce-bd4d-1c67164cb890)
